### PR TITLE
Factor out contact info from the warning message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,9 @@ inputs:
     description: 'Message posted on issue as unassign warning'
     required: false
     default: "Thanks for picking up this issue and supporting this project! It looks like there hasn’t been any activity on this ticket in a while. To keep things moving, you will be unassigned from this issue soon if there’s no new activity on it by then. But we encourage you to pick this issue (or a new one) back up in the future!"
-  office_hours:
-    description: 'Slack office hours included in warning or unassign message'
-    required: false
-    default: ''
+  contact_message:
+    description: 'Contact info sent along with the warning'
+    required: true
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const unassignInactiveInHours = core.getInput('unassign_inactive_in_hours');
 const unassignInactiveMessage = core.getInput('unassign_inactive_message');
 const warningInactiveInHours = core.getInput('warning_inactive_in_hours');
 const warningInactiveMessage = core.getInput('warning_inactive_message');
-const officeHours = core.getInput('office_hours');
+const contactMessage = core.getInput('contact_message');
 const repoOwner = github.context.repo.owner;
 const repo = github.context.repo.repo;
 const octokit = github.getOctokit(token);
@@ -177,9 +177,7 @@ async function main() {
                      `hours (${(timeInactiveInHours/24).toFixed(2)} days) ` +
                      `and will be unassigned after ${willBeUnassignedInHours} ` +
                      `more hours (${(willBeUnassignedInHours/24).toFixed(2)} days). ` +
-                     `If you have questions, please visit the #casa channel in slack during ` + 
-                     `${officeHours}`+ `. ` + 
-                     `Link: https://rubyforgood.herokuapp.com/ \n\n` + 
+                     `If you have questions, please ${contactMessage} \n\n` +
                      `${warningInactiveMessage}`;
         try {
           await octokit.issues.createComment({


### PR DESCRIPTION
Resolves #7

Since there was ruby for good / casa specific info before & after the use of `officeHours` I decided to replace it completely by `contactMessage` instead of creating 2 new inputs.